### PR TITLE
Changes to add M5Stack Core2 and M5Stack TubePressure unit

### DIFF
--- a/ESP32/DIY-Flow-Bench/calculations.cpp
+++ b/ESP32/DIY-Flow-Bench/calculations.cpp
@@ -381,7 +381,7 @@ double Calculations::convertVelocityToVolumetric(double velocityFpm, double pipe
 
   double CFM;
   
-  CFM = velocityFpm * pow(PI * pipeRadiusFt, 2) ;
+  CFM = velocityFpm * (PI * pow(pipeRadiusFt, 2));
 
   return CFM;
   

--- a/ESP32/DIY-Flow-Bench/configuration.h
+++ b/ESP32/DIY-Flow-Bench/configuration.h
@@ -53,12 +53,12 @@
 * NOTE: If defining new board make sure to add board type definition to pins.h
 ***/
 
-#define WEMOS_D1_R32 // Using official Shield
+// #define WEMOS_D1_R32 // Using official Shield
 // #define ESP32DUINO // Generic pin mapping for ESP32 UNO style footprint. Copy or modify this for custom board mapping
 // #define ARDUCAM_ESP32S // Untested - Needs validating + refining
 // #define ARDUCAM_LOTAI  // Untested - Needs validating + refining
 // #define ESP32_WROVER_KIT // DEBUG BUILD ONLY
-
+#define ARDUINO_M5STACK_CORE2 // DEBUG BUILD ONLY 
 
 
 
@@ -277,10 +277,10 @@ const int ADC_I2C_ADDR = 0x48;
 // #define PREF_SENSOR_TYPE_MPXV7007        
 // #define PREF_SENSOR_TYPE_MPXV7025
 // #define PREF_SENSOR_TYPE_XGZP6899A007KPDPN        
-#define PREF_SENSOR_TYPE_XGZP6899A010KPDPN        
+// #define PREF_SENSOR_TYPE_XGZP6899A010KPDPN        
+#define PREF_SENSOR_TYPE_M5STACK_TubePressure        
 
-
-#define PREF_MV_TRIMPOT 0.0                               // Millivolt offset
+#define PREF_MV_TRIMPOT -0.010999                         // Millivolt offset
 #define PREF_ANALOG_SCALE 1.0                             // Scaling factor used for raw analog value
 #define PREF_ADC_CHANNEL 1                                
 
@@ -305,12 +305,13 @@ const int ADC_I2C_ADDR = 0x48;
 
 // Set sensor type (Uncomment One line only)   
 // #define PDIFF_SENSOR_TYPE_LINEAR_ANALOG 
-#define PDIFF_SENSOR_TYPE_MPXV7007          
+// #define PDIFF_SENSOR_TYPE_MPXV7007          
 // #define PDIFF_SENSOR_TYPE_MPXV7025
 // #define PDIFF_SENSOR_TYPE_XGZP6899A007KPDPN        
 // #define PDIFF_SENSOR_TYPE_XGZP6899A010KPDPN        
+#define PDIFF_SENSOR_TYPE_M5STACK_TubePressure       
 
-#define PDIFF_MV_TRIMPOT 0.0                              // Millivolt offset
+#define PDIFF_MV_TRIMPOT -0.007                           // Millivolt offset
 #define PDIFF_ANALOG_SCALE 1.0                            // Scaling factor used for raw analog value
 #define PDIFF_ADC_CHANNEL 2                               
 
@@ -335,12 +336,13 @@ const int ADC_I2C_ADDR = 0x48;
 // Set sensor type (Uncomment One line only)
 // #define PITOT_SENSOR_NOT_USED
 // #define PITOT_SENSOR_TYPE_LINEAR_ANALOG                // Use analog signal from PITOT_PIN
-#define PITOT_SENSOR_TYPE_MPXV7007
+// #define PITOT_SENSOR_TYPE_MPXV7007
 // #define PITOT_SENSOR_TYPE_MPXV7025
 // #define PITOT_SENSOR_TYPE_XGZP6899A007KPDPN        
 // #define PITOT_SENSOR_TYPE_XGZP6899A010KPDPN        
+#define PITOT_SENSOR_TYPE_M5STACK_TubePressure        
 
-#define PITOT_MV_TRIMPOT 0.0                              // Millivolt offset
+#define PITOT_MV_TRIMPOT -0.0120249                       // Millivolt offset
 #define PITOT_ANALOG_SCALE 1.0                            // Scaling factor used for raw analog value
 #define PITOT_ADC_CHANNEL 3
 

--- a/ESP32/DIY-Flow-Bench/configuration.h
+++ b/ESP32/DIY-Flow-Bench/configuration.h
@@ -26,7 +26,7 @@
 
 #define MAJOR_VERSION "V2"
 #define MINOR_VERSION "0"
-#define BUILD_NUMBER "24110201"
+#define BUILD_NUMBER "24110301"
 #define RELEASE "V.2.0-RC.8"
 #define DEV_BRANCH "https://github.com/DeeEmm/DIY-Flow-Bench/tree/WIP"
 
@@ -53,12 +53,12 @@
 * NOTE: If defining new board make sure to add board type definition to pins.h
 ***/
 
-// #define WEMOS_D1_R32 // Using official Shield
+#define WEMOS_D1_R32 // Using official Shield
 // #define ESP32DUINO // Generic pin mapping for ESP32 UNO style footprint. Copy or modify this for custom board mapping
 // #define ARDUCAM_ESP32S // Untested - Needs validating + refining
 // #define ARDUCAM_LOTAI  // Untested - Needs validating + refining
 // #define ESP32_WROVER_KIT // DEBUG BUILD ONLY
-#define ARDUINO_M5STACK_CORE2 // DEBUG BUILD ONLY 
+// #define ARDUINO_M5STACK_CORE2 // DEBUG BUILD ONLY 
 
 
 
@@ -274,11 +274,11 @@ const int ADC_I2C_ADDR = 0x48;
 
 // Set sensor type (Uncomment One line only)
 // #define PREF_SENSOR_TYPE_LINEAR_ANALOG 
-// #define PREF_SENSOR_TYPE_MPXV7007        
+#define PREF_SENSOR_TYPE_MPXV7007        
 // #define PREF_SENSOR_TYPE_MPXV7025
 // #define PREF_SENSOR_TYPE_XGZP6899A007KPDPN        
 // #define PREF_SENSOR_TYPE_XGZP6899A010KPDPN        
-#define PREF_SENSOR_TYPE_M5STACK_TubePressure        
+// #define PREF_SENSOR_TYPE_M5STACK_TubePressure        
 
 #define PREF_MV_TRIMPOT -0.010999                         // Millivolt offset
 #define PREF_ANALOG_SCALE 1.0                             // Scaling factor used for raw analog value
@@ -305,11 +305,11 @@ const int ADC_I2C_ADDR = 0x48;
 
 // Set sensor type (Uncomment One line only)   
 // #define PDIFF_SENSOR_TYPE_LINEAR_ANALOG 
-// #define PDIFF_SENSOR_TYPE_MPXV7007          
+#define PDIFF_SENSOR_TYPE_MPXV7007          
 // #define PDIFF_SENSOR_TYPE_MPXV7025
 // #define PDIFF_SENSOR_TYPE_XGZP6899A007KPDPN        
 // #define PDIFF_SENSOR_TYPE_XGZP6899A010KPDPN        
-#define PDIFF_SENSOR_TYPE_M5STACK_TubePressure       
+// #define PDIFF_SENSOR_TYPE_M5STACK_TubePressure       
 
 #define PDIFF_MV_TRIMPOT -0.007                           // Millivolt offset
 #define PDIFF_ANALOG_SCALE 1.0                            // Scaling factor used for raw analog value
@@ -336,11 +336,11 @@ const int ADC_I2C_ADDR = 0x48;
 // Set sensor type (Uncomment One line only)
 // #define PITOT_SENSOR_NOT_USED
 // #define PITOT_SENSOR_TYPE_LINEAR_ANALOG                // Use analog signal from PITOT_PIN
-// #define PITOT_SENSOR_TYPE_MPXV7007
+#define PITOT_SENSOR_TYPE_MPXV7007
 // #define PITOT_SENSOR_TYPE_MPXV7025
 // #define PITOT_SENSOR_TYPE_XGZP6899A007KPDPN        
 // #define PITOT_SENSOR_TYPE_XGZP6899A010KPDPN        
-#define PITOT_SENSOR_TYPE_M5STACK_TubePressure        
+// #define PITOT_SENSOR_TYPE_M5STACK_TubePressure        
 
 #define PITOT_MV_TRIMPOT -0.0120249                       // Millivolt offset
 #define PITOT_ANALOG_SCALE 1.0                            // Scaling factor used for raw analog value

--- a/ESP32/DIY-Flow-Bench/hardware.cpp
+++ b/ESP32/DIY-Flow-Bench/hardware.cpp
@@ -56,14 +56,27 @@ Hardware::Hardware() {
 void Hardware::configurePins () {
  
   // Inputs
+  #ifdef VCC_3V3_PIN
   pinMode(VCC_3V3_PIN, INPUT); 
-  pinMode(VCC_5V_PIN, INPUT); 
+  #endif
 
-  pinMode(SPEED_SENSOR_PIN, INPUT); 
+  pinMode(VCC_5V_PIN, INPUT);    //This is required as it is used to get the supply voltage for the MPVX7007 pressure calc.
+
+  #ifdef SPEED_SENSOR_PIN
+  pinMode(SPEED_SENSOR_PIN, INPUT);
+  #endif
+
+  #ifdef ORIFICE_BCD_BIT1_PIN
   pinMode(ORIFICE_BCD_BIT1_PIN, INPUT); 
-  pinMode(ORIFICE_BCD_BIT2_PIN, INPUT); 
-  pinMode(ORIFICE_BCD_BIT3_PIN, INPUT); 
+  #endif
 
+  #ifdef ORIFICE_BCD_BIT2_PIN
+  pinMode(ORIFICE_BCD_BIT2_PIN, INPUT); 
+  #endif
+
+  #ifdef ORIFICE_BCD_BIT3_PIN
+  pinMode(ORIFICE_BCD_BIT3_PIN, INPUT); 
+  #endif
 
   #ifdef MAF_SRC_IS_PIN
   pinMode(MAF_PIN, INPUT); 
@@ -93,26 +106,43 @@ void Hardware::configurePins () {
   
 
   // Outputs
+  #ifdef VAC_BANK_1_PIN
   pinMode(VAC_BANK_1_PIN, OUTPUT);
+  #endif
+
+  #ifdef VAC_BANK_2_PIN
   pinMode(VAC_BANK_2_PIN, OUTPUT);
+  #endif
+
+  #ifdef VAC_BANK_3_PIN
   pinMode(VAC_BANK_3_PIN, OUTPUT);
-  
+  #endif
+
+  #ifdef VAC_SPEED_PIN
   pinMode(VAC_SPEED_PIN, OUTPUT);
+  #endif
+
+  #ifdef VAC_BLEED_VALVE_PIN
   pinMode(VAC_BLEED_VALVE_PIN, OUTPUT);
+  #endif
 
+  #ifdef AVO_STEP_PIN
   pinMode(AVO_STEP_PIN, OUTPUT);
+  #endif
+
+  #ifdef AVO_DIR_PIN
   pinMode(AVO_DIR_PIN, OUTPUT);
+  #endif
 
+  #ifdef FLOW_VALVE_STEP_PIN
   pinMode(FLOW_VALVE_STEP_PIN, OUTPUT);
+  #endif
+
+  #ifdef FLOW_VALVE_DIR_PIN
   pinMode(FLOW_VALVE_DIR_PIN, OUTPUT);
-
-
-
+  #endif
 
 }
-
-
-
 
 /***********************************************************
  * @brief begin function
@@ -333,8 +363,10 @@ double Hardware::get5vSupplyVolts() {
  ***/
 double Hardware::get3v3SupplyVolts() {   
 
+  #ifdef VCC_3V3_PIN  
   long rawVoltageValue = analogRead(VCC_3V3_PIN);  
   double vcc3v3SupplyVolts = (2 * rawVoltageValue * 0.805860805860806) ;
+  #endif
 
   #ifdef USE_FIXED_3_3V_VALUE
     return 3.3; 

--- a/ESP32/DIY-Flow-Bench/pins.h
+++ b/ESP32/DIY-Flow-Bench/pins.h
@@ -408,4 +408,70 @@
 // #define WEMOS_SPARE_PIN_3           33                    
 #endif
 
+/***********************************************************
+ * M5STACK CORE2
+ * UNTESTED
+ * NOTE M5STACK CORE2 has SD card on GPIOs 4/23/38/18
+ *
+  ***/
+#ifdef ARDUINO_M5STACK_CORE2
 
+    #define BOARD_TYPE              "m5stack-core2"
+
+    // Define Physical Pins
+    
+    // VAC CONTROL
+    //#define VAC_SPEED_PIN               -1                      // Built in DAC1 - used for speed reference for VFD (0-3v)
+    //#define VAC_BLEED_VALVE_PIN         -1                      // Built in DAC2 - used for bleed valve control
+    
+    #define VAC_BANK_1_PIN                19                      // vac motor(s) on/off
+    //#define VAC_BANK_2_PIN              -1                      // Provision for 2 stage Vac motor control
+    //#define VAC_BANK_3_PIN              -1                      // Provision for 3 stage Vac motor control
+    
+    // SENSORS
+    //#define SPEED_SENSOR_PIN            -1                      // turbine / rotor speed for turbo / blower flow bench
+
+    // SWIRL ENCODER
+    //#define SWIRL_ENCODER_PIN_A         -1
+    //#define SWIRL_ENCODER_PIN_B        -1
+
+    // ORIFICE DETECTION                                                                                    
+    //#define ORIFICE_BCD_BIT1_PIN        -1                     
+    //#define ORIFICE_BCD_BIT2_PIN        -1                    
+    //#define ORIFICE_BCD_BIT3_PIN        -1     
+
+    //STEPPER MOTOR CONTROLLER                  
+    //#define FLOW_VALVE_STEP_PIN        -1
+    //#define FLOW_VALVE_DIR_PIN         -1
+                  
+    //#define AVO_STEP_PIN               -1
+    //#define AVO_DIR_PIN                -1
+
+    //#define VCC_3V3_PIN                 27                    // Unused
+    #define VCC_5V_PIN                  35                    // 10k-10k divider across 5v supply, This is required as it is used to get the supply voltage for the MPVX7007 pressure calc.
+    
+    // NOTE: these inputs are handled by ADC
+    #define MAF_PIN                     -1                     // NOTE: I2C ADC is used instead
+    #define REF_PRESSURE_PIN            -1                     // NOTE: I2C ADC is used instead, recommened but not essential for a MAF bench, essential for Differential type bench
+    #define DIFF_PRESSURE_PIN           -1                     // NOTE: I2C ADC is used instead, only required for Differential 
+    #define PITOT_PIN                   -1                     // NOTE: I2C ADC is used instead, only required if using a pitot probe
+    
+    // NOTE: These inputs are handled by BME280/BME68X
+    #define TEMPERATURE_PIN             -1                     // NOTE: I2C BME280 used
+    #define REF_BARO_PIN                -1                     // NOTE: I2C BME280 used
+    #define HUMIDITY_PIN                -1                     // NOTE: I2C BME280 used                     
+    
+    // COMMS    
+    #define SERIAL0_TX_PIN              1                      // API
+    #define SERIAL0_RX_PIN              3                      // API
+    //#define SERIAL2_TX_PIN              -1                     // GAUGE PROTOCOL CLOCK
+    //#define SERIAL2_RX_PIN              -1                     // GAUGE PROTOCOL DATA
+    #define SDA_PIN                     32                     // BME280 etc
+    #define SCL_PIN                     33                     // BME280 etc
+    
+    #define SD_CS_PIN                   4
+    #define SD_MOSI_PIN                 23                 
+    #define SD_MISO_PIN                 38             
+    #define SD_SCK_PIN                  18                   
+
+#endif

--- a/ESP32/DIY-Flow-Bench/sensors.cpp
+++ b/ESP32/DIY-Flow-Bench/sensors.cpp
@@ -650,6 +650,13 @@ double Sensors::getPRefValue() {
 		// Linear response. Range = 0.5 ~ 4.5 = -10 ~ 10kPa
 		sensorVal = sensorVolts * 5 - 12.5;
 
+	#elif defined PREF_SENSOR_TYPE_M5STACK_TubePressure
+
+		//P: Actual test pressure value, unit (Kpa)
+		//Vout: sensor voltage output value
+		//P = (Vout-0.1)/3.0*300.0-100.0
+		sensorVal = (sensorVolts-0.1)/3.0*300.0-100.0;	
+
 	#else
 
 		sensorVal = FIXED_REF_PRESS_VALUE;
@@ -748,7 +755,13 @@ double Sensors::getPDiffValue() {
 		// Linear response. Range = 0.5 ~ 4.5 = -10 ~ 10kPa
 		sensorVal = sensorVolts * 5 - 12.5
 
+	#elif defined PDIFF_SENSOR_TYPE_M5STACK_TubePressure
 
+		//P: Actual test pressure value, unit (Kpa)
+		//Vout: sensor voltage output value
+		//P = (Vout-0.1)/3.0*300.0-100.0
+		sensorVal = (sensorVolts-0.1)/3.0*300.0-100.0;
+	
 	#else // use fixed value
 
 		sensorVal = FIXED_PDIFF_PRESS;
@@ -847,7 +860,12 @@ double Sensors::getPitotValue() {
 		// Linear response. Range = 0.5 ~ 4.5 = -10 ~ 10kPa
 		sensorVal = sensorVolts * 5 - 12.5
 
+	#elif defined PITOT_SENSOR_TYPE_M5STACK_TubePressure
 
+		//P: Actual test pressure value, unit (Kpa)
+		//Vout: sensor voltage output value
+		//P = (Vout-0.1)/3.0*300.0-100.0
+		sensorVal = (sensorVolts-0.1)/3.0*300.0-100.0;
 
 	#else // use fixed value
 

--- a/ESP32/DIY-Flow-Bench/sensors.cpp
+++ b/ESP32/DIY-Flow-Bench/sensors.cpp
@@ -853,12 +853,12 @@ double Sensors::getPitotValue() {
 	#elif defined PITOT_SENSOR_TYPE_XGZP6899A007KPDPN
 
 		// Linear response. Range = 0.5 ~ 4.5 = -7 ~ 7kPa
-		sensorVal = sensorVolts * 3.5 - 8.75
+		sensorVal = sensorVolts * 3.5 - 8.75;
 
 	#elif defined PITOT_SENSOR_TYPE_XGZP6899A010KPDPN
 
 		// Linear response. Range = 0.5 ~ 4.5 = -10 ~ 10kPa
-		sensorVal = sensorVolts * 5 - 12.5
+		sensorVal = sensorVolts * 5 - 12.5;
 
 	#elif defined PITOT_SENSOR_TYPE_M5STACK_TubePressure
 

--- a/ESP32/DIY-Flow-Bench/sensors.cpp
+++ b/ESP32/DIY-Flow-Bench/sensors.cpp
@@ -748,12 +748,12 @@ double Sensors::getPDiffValue() {
 	#elif defined PDIFF_SENSOR_TYPE_XGZP6899A007KPDPN
 
 		// Linear response. Range = 0.5 ~ 4.5 = -7 ~ 7kPa
-		sensorVal = sensorVolts * 3.5 - 8.75
+		sensorVal = sensorVolts * 3.5 - 8.75;
 
 	#elif defined PDIFF_SENSOR_TYPE_XGZP6899A010KPDPN
 
 		// Linear response. Range = 0.5 ~ 4.5 = -10 ~ 10kPa
-		sensorVal = sensorVolts * 5 - 12.5
+		sensorVal = sensorVolts * 5 - 12.5;
 
 	#elif defined PDIFF_SENSOR_TYPE_M5STACK_TubePressure
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -54,9 +54,10 @@ build_flags =
 [env:release]
 build_type = release
 ; board = esp-wrover-kit
-board = esp32dev
+; board = esp32dev
 ; board = wemos_d1_uno32
 ; board = ArduCAM_ESP32S_UNO
+board = m5stack-core2
 upload_protocol = esptool
 ; upload_speed = 921600
 upload_speed = 460800
@@ -92,3 +93,24 @@ lib_deps =
 	https://github.com/fabyte/Tiny_BME280_Arduino_Library.git
 lib_ignore = 
 	SPI
+
+[env:m5stack-core2]
+board = m5stack-core2
+upload_protocol = esptool
+upload_speed = 460800
+lib_ldf_mode = chain
+lib_deps = 
+	bblanchon/ArduinoJson@^6.19.4
+	esphome/AsyncTCP-esphome
+	esphome/ESPAsyncWebServer-esphome
+	https://github.com/terryjmyers/ADS1115-Lite.git
+	https://github.com/fabyte/Tiny_BME280_Arduino_Library.git
+	majicdesigns/MD_REncoder@^1.0.1
+	;m5stack/M5Unified@^0.1.17
+	;M5GFX
+	lbernstone/UncleRus@^1.0.1
+	M5_ADS1100
+	M5Unit-PbHub
+	bsec2
+	BME68x Sensor library
+lib_ignore = 


### PR DESCRIPTION
Changes made to;
platformio.ini new env to add board type
pins.h added for M5Stack Core2
configuration.h define M5Stack Core2 and TubePressure unit for Pref, Diff and PITOT
hardware.cpp changes to configurePins to allow them to be commented out in the pins.h and to get3v3SupplyVolts for the same reason
sensors.cpp add the sensor maths for Pref, Diff and PITOT