### PR TITLE
Build 24110701        - Changed min pressure threshold to allow -ve values

### DIFF
--- a/ESP32/DIY-Flow-Bench/DIY-Flow-Bench.ino
+++ b/ESP32/DIY-Flow-Bench/DIY-Flow-Bench.ino
@@ -43,6 +43,7 @@
 #include <MD_REncoder.h>
 #include <math.h>
 
+#include "version.h"
 #include "constants.h"
 #include "configuration.h"
 #include "structs.h"

--- a/ESP32/DIY-Flow-Bench/configuration.h
+++ b/ESP32/DIY-Flow-Bench/configuration.h
@@ -20,18 +20,6 @@
 
 #include "constants.h"
 
-
-// Don't forget to update the changelog & README Versions!!
-// TODO: Automate build numbering with git tasks
-
-#define MAJOR_VERSION "V2"
-#define MINOR_VERSION "0"
-#define BUILD_NUMBER "24110403"
-#define RELEASE "V.2.0-RC.8"
-#define DEV_BRANCH "https://github.com/DeeEmm/DIY-Flow-Bench/tree/WIP"
-
-
-
 /***********************************************************
 * SELECT DEFAULT BENCH TYPE
 * NOTE: Only MAF style bench working at this stage

--- a/ESP32/DIY-Flow-Bench/sensors.cpp
+++ b/ESP32/DIY-Flow-Bench/sensors.cpp
@@ -612,7 +612,6 @@ double Sensors::getPRefVolts() {
 		return 0.0;
 	}
 
-
 }
 
 
@@ -627,7 +626,9 @@ double Sensors::getPRefVolts() {
 double Sensors::getPRefValue() {
 
 	Hardware _hardware;
-	
+	extern struct ConfigSettings config;
+
+
 	double sensorVal = 0.0;
 	double sensorVolts = this->getPRefVolts();
 	
@@ -670,12 +671,12 @@ double Sensors::getPRefValue() {
 	#endif
 
 	// Lets make sure we have a valid value to return
-	if (sensorVal > 0) { 
+	double pRefComp = fabs(sensorVal);
+	if (pRefComp > config.min_bench_pressure) { 
 		return sensorVal;
 	} else { 
 		return 0.0001; // return small non zero value to prevent divide by zero errors (will be truncated to zero in display)
 	}
-
 
 }
 
@@ -729,6 +730,8 @@ double Sensors::getPDiffVolts() {
  ***/
 double Sensors::getPDiffValue() {
 
+	extern struct ConfigSettings config; 
+
 	Hardware _hardware;
 
 	double sensorVal = 0.0;
@@ -774,12 +777,13 @@ double Sensors::getPDiffValue() {
 
 	#endif
 
-	// Lets make sure we have a valid value to return
-	if (sensorVal > 0) {
+	// Lets make sure we have a valid value to return - check it is above minimum threshold
+	double pDiffComp = fabs(sensorVal);
+	if (pDiffComp > config.min_bench_pressure) { 
 		return sensorVal;
-	} else {
-		return 0.0001;
-	}
+	} else { 
+		return 0.0001; // return small non zero value to prevent divide by zero errors (will be truncated to zero in display)
+	}	
 
 }
 
@@ -834,6 +838,8 @@ double Sensors::getPitotVolts() {
  ***/
 double Sensors::getPitotValue() {
 	
+	extern struct ConfigSettings config;
+
 	Hardware _hardware;
 
 	double sensorVal = 0.0;
@@ -879,12 +885,13 @@ double Sensors::getPitotValue() {
 
 	#endif
 
-	// Lets make sure we have a valid value to return
-	if (sensorVal > 0) {
+	// Lets make sure we have a valid value to return - check it is above minimum threshold
+	double pitotComp = fabs(sensorVal);
+	if (pitotComp > config.min_bench_pressure) { 
 		return sensorVal;
-	} else {
-		return 0.0001;
-	}
+	} else { 
+		return 0.0001; // return small non zero value to prevent divide by zero errors (will be truncated to zero in display)
+	}	
 
 }
 

--- a/ESP32/DIY-Flow-Bench/version.h
+++ b/ESP32/DIY-Flow-Bench/version.h
@@ -1,0 +1,8 @@
+// Don't forget to update the changelog & README Versions!!
+// TODO: Automate build numbering with git tasks
+
+#define MAJOR_VERSION "V2"
+#define MINOR_VERSION "0"
+#define BUILD_NUMBER "24110701"
+#define RELEASE "V.2.0-RC.8"
+#define DEV_BRANCH "https://github.com/DeeEmm/DIY-Flow-Bench/tree/WIP"

--- a/docs/changelog
+++ b/docs/changelog
@@ -58,6 +58,8 @@ Build numbers follow format YY MM DD VV Where VV is the incremental daily versio
 
 Build #         - Description of Change
 
+24110701        - Changed min pressure threshold to allow -ve values
+                - Moved version vars into dedicated file
 24110701        - M5Stack Tube pressure sensors initialisation
                 - Correction to MAF rescaling function
 24110403        - Added HTTP API Call for JSON Data


### PR DESCRIPTION
24110702        - Added missing line terminator from PR #198
                - Added missing #includes for version.h
                - Updated esp-wrover-kit debug env in platformio 
                - Removed desk type selection from configuration.h