### PR TITLE
Update calculations.cpp

### DIFF
--- a/ESP32/DIY-Flow-Bench/calculations.cpp
+++ b/ESP32/DIY-Flow-Bench/calculations.cpp
@@ -356,7 +356,7 @@ double Calculations::convertFlowDepression(double oldPressure, double newPressur
     if (newPressure == oldPressure) {
       return inputFlowCFM;
     } else {
-      pressureRatio = (newPressure / oldPressure);
+      pressureRatio = (abs(newPressure) / abs(oldPressure));
     }
     scaleFactor = sqrt(pressureRatio);
     outputFlow =  inputFlowCFM * scaleFactor;

--- a/ESP32/DIY-Flow-Bench/version.h
+++ b/ESP32/DIY-Flow-Bench/version.h
@@ -3,6 +3,6 @@
 
 #define MAJOR_VERSION "V2"
 #define MINOR_VERSION "0"
-#define BUILD_NUMBER "24110802"
+#define BUILD_NUMBER "24110901"
 #define RELEASE "V.2.0-RC.8"
 #define DEV_BRANCH "https://github.com/DeeEmm/DIY-Flow-Bench/tree/WIP"

--- a/docs/changelog
+++ b/docs/changelog
@@ -58,6 +58,7 @@ Build numbers follow format YY MM DD VV Where VV is the incremental daily versio
 
 Build #         - Description of Change
 
+24110901        - Changed the pressure ratio formula to allow +/-ve values to be calculated
 24110802        - #207 Decimal places on GUI
 24110801        - Code tidy up so the pressure sensors are correctly reported in the web GUI info page
 24110704        - Updated calls to #include "version.h"


### PR DESCRIPTION
Changed the pressure ratio formula so it takes the absolute values for the new and old pressure, this allows the square root of the pressure ratio to be calculated. C++ with the std::sqrt does not return a value for a negative number.