### PR TITLE
GUI change to how Pitot Delta is displayed

### DIFF
--- a/ESP32/DIY-Flow-Bench/data/index.html
+++ b/ESP32/DIY-Flow-Bench/data/index.html
@@ -1392,7 +1392,7 @@ if (!!window.EventSource) {
            if (key === 'FLOW' || key === 'AFLOW' || key === 'MFLOW' || key === 'SFLOW' || key === 'FDIFF') {
               // HACK: template vars - replaced before page load
               document.getElementById(key).innerHTML = myObj[key].toFixed(~FLOW_DECIMAL_LENGTH~);  
-            } else if (key === 'PREF' || key === 'PDIFF' || key === 'PITOT' || key === 'SWIRL' || key === 'TEMP' || key === 'BARO' || key === 'RELH') {
+            } else if (key === 'PREF' || key === 'PDIFF' || key === 'PITOT' || key === 'PITOT_DELTA' ||key === 'SWIRL' || key === 'TEMP' || key === 'BARO' || key === 'RELH') {
               document.getElementById(key).innerHTML = myObj[key].toFixed(~GEN_DECIMAL_LENGTH~); 
             //} else if (key === '') {
             } else {

--- a/ESP32/DIY-Flow-Bench/src/javascript.js
+++ b/ESP32/DIY-Flow-Bench/src/javascript.js
@@ -60,7 +60,7 @@ if (!!window.EventSource) {
            if (key === 'FLOW' || key === 'AFLOW' || key === 'MFLOW' || key === 'SFLOW' || key === 'FDIFF') {
               // HACK: template vars - replaced before page load
               document.getElementById(key).innerHTML = myObj[key].toFixed(~FLOW_DECIMAL_LENGTH~);  
-            } else if (key === 'PREF' || key === 'PDIFF' || key === 'PITOT' || key === 'SWIRL' || key === 'TEMP' || key === 'BARO' || key === 'RELH') {
+            } else if (key === 'PREF' || key === 'PDIFF' || key === 'PITOT' || key === 'PITOT_DELTA' ||key === 'SWIRL' || key === 'TEMP' || key === 'BARO' || key === 'RELH') {
               document.getElementById(key).innerHTML = myObj[key].toFixed(~GEN_DECIMAL_LENGTH~); 
             //} else if (key === '') {
             } else {


### PR DESCRIPTION
A suggested change to the Pitot GUI so that the ∆ is displayed with a decimal display that follows the General decimal accuracy that is set from the Configuration GUI page.